### PR TITLE
Docs: Align README with brake key behavior changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Below is the mapping of buttons and their corresponding button codes (all codes 
 | X | 00002000 | None | Left steering control (default; you need pairing Square in Zwift) |
 | Square | 00001000 | h | Toggle HUD |
 | Left Campagnolo | 00008000 | Left Arrow| Navigate left |
-| Left brake | 00004000 | 6 | Change to backforward view |
+| Left brake | 00004000 | Toggles '6'/'1' | Toggles backward/forward camera view |
 | Left shift 1 | 00000002 | None | (Reserved for virtual gears) |
 | Left shift 2 | 00000001 | None | (Reserved for virtual gears) |
 | Y | 02000000 | g | Alternate power and watts and FC view |
@@ -67,7 +67,7 @@ Below is the mapping of buttons and their corresponding button codes (all codes 
 | Circle | 20000000 | None | Rigth steering control (default; you need pairing Square in Zwift) |
 | Triangle | 10000000 | Space | Activate powerup |
 | Right Campagnolo | 80000000 | Rigth Arrow | Navigate Right |
-| Right brake | 40000000 | 1 | Change to forward view |
+| Right brake | 40000000 | None | No view change function |
 | Right shift 1 | 00020000 | None | (Reserved for virtual gears) |
 | Right shift 2 | 00010000 | None | (Reserved for virtual gears) |
 

--- a/square_controller.py
+++ b/square_controller.py
@@ -41,7 +41,7 @@ KEY_MAPPING = {
     "X": None, # left steering
     "Square": KeyCode.from_char('r'), # pairing screen, 
     "Left Campagnolo": Key.left,
-    "Left brake": KeyCode.from_char('6'), # backward view
+    "Left brake": None, # Toggles backward/forward view ('6'/'1')
     "Left shift 1": None,
     "Left shift 2": None,
     "Y": KeyCode.from_char('g'), # alternate power and watts and FC 
@@ -51,7 +51,7 @@ KEY_MAPPING = {
     "Circle": None, # Right steering
     "Triangle": Key.space, # Activate powerup
     "Right Campagnolo": Key.right,
-    "Right brake": KeyCode.from_char('1'), # fordward view
+    "Right brake": None,
     "Right shift 1": None,
     "Right shift 2": None
 }
@@ -59,6 +59,7 @@ KEY_MAPPING = {
 # Variable to store the last value
 last_value = None
 keyboard = Controller()
+left_brake_is_forward_view = False
 
 def extract_button_code(hex_value):
     """Extract the relevant part of the hex value that identifies the button"""
@@ -78,7 +79,7 @@ def extract_button_code(hex_value):
 
 def notification_handler(sender, data):
     """Handler for notifications received from the BLE device"""
-    global last_value
+    global last_value, left_brake_is_forward_view
     full_value = data.hex()
     
     # Extract the relevant part of the value that identifies the button
@@ -103,7 +104,17 @@ def notification_handler(sender, data):
             print(f"Button pressed: {button_name} (full hex: {full_value}, button code: {current_value})")
         
         # Simulate key press if it's a valid button
-        if button_name != "No button pressed":
+        if button_name == "Left brake":
+            left_brake_is_forward_view = not left_brake_is_forward_view
+            if left_brake_is_forward_view:
+                key = KeyCode.from_char('1')
+                print(f"Simulating key press: {key} (Left brake - forward view)")
+            else:
+                key = KeyCode.from_char('6')
+                print(f"Simulating key press: {key} (Left brake - backward view)")
+            keyboard.press(key)
+            keyboard.release(key)
+        elif button_name != "No button pressed":
             key = KEY_MAPPING.get(button_name)
             if key:
                 print(f"Simulating key press: {key}")


### PR DESCRIPTION
Updates the "Button Mapping" table in README.md to accurately describe the current functionality of the "Left brake" and "Right brake" keys:

- "Left brake": Clarifies that it toggles between backward ('6') and forward ('1') camera views.
- "Right brake": Reflects that it no longer has a dedicated view change function.